### PR TITLE
chore(release): cut 1.0.0-beta03

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ repositories {
 }
 
 dependencies {
-    val katalyst = "1.0.0-beta02" // latest version — see the Maven Central badge above
+    val katalyst = "1.0.0-beta03" // latest version — see the Maven Central badge above
     implementation(platform("io.github.darkryh.katalyst:katalyst-bom:$katalyst"))
 
     implementation("io.github.darkryh.katalyst:katalyst-starter-web")

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,7 +39,7 @@ plugins {
 repositories { mavenCentral() }
 
 dependencies {
-    val katalyst = "1.0.0-beta02"
+    val katalyst = "1.0.0-beta03"
     implementation(platform("io.github.darkryh.katalyst:katalyst-bom:$katalyst"))
     implementation("io.github.darkryh.katalyst:katalyst-starter-web")
     implementation("io.github.darkryh.katalyst:katalyst-starter-engine-netty")

--- a/docs/how-to/test-applications.md
+++ b/docs/how-to/test-applications.md
@@ -11,7 +11,7 @@ declare for the main dependencies, so add the BOM to the test configuration too 
 starter's version:
 
 ```kotlin
-testImplementation(platform("io.github.darkryh.katalyst:katalyst-bom:1.0.0-beta02"))
+testImplementation(platform("io.github.darkryh.katalyst:katalyst-bom:1.0.0-beta03"))
 testImplementation("io.github.darkryh.katalyst:katalyst-starter-test")
 ```
 

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -2,11 +2,11 @@
 
 Katalyst is published as a set of focused modules under the group
 `io.github.darkryh.katalyst`. Depend only on what you use. All modules share the same
-version (current line: `1.0.0-beta02`). Applications should consume the BOM and feature
+version (current line: `1.0.0-beta03`). Applications should consume the BOM and feature
 starters; the lower-level modules below remain useful for advanced integrations.
 
 ```kotlin
-val katalyst = "1.0.0-beta02"
+val katalyst = "1.0.0-beta03"
 implementation(platform("io.github.darkryh.katalyst:katalyst-bom:$katalyst"))
 implementation("io.github.darkryh.katalyst:katalyst-starter-web")
 implementation("io.github.darkryh.katalyst:katalyst-starter-engine-netty")
@@ -96,7 +96,7 @@ Pull all three in at once with the `katalyst-starter-observability` starter.
 A full-featured service usually pulls in:
 
 ```kotlin
-val katalyst = "1.0.0-beta02"
+val katalyst = "1.0.0-beta03"
 implementation(platform("io.github.darkryh.katalyst:katalyst-bom:$katalyst"))
 implementation("io.github.darkryh.katalyst:katalyst-starter-web")
 implementation("io.github.darkryh.katalyst:katalyst-starter-engine-netty")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
 katalystGroup=io.github.darkryh.katalyst
-katalystVersion=1.0.0-beta02
+katalystVersion=1.0.0-beta03
 org.gradle.configuration-cache=true
 org.gradle.caching=true

--- a/harness/consumer-smoke/build.gradle.kts
+++ b/harness/consumer-smoke/build.gradle.kts
@@ -5,7 +5,7 @@ import org.gradle.api.tasks.testing.Test
 plugins {
     // The ONLY plugin a Katalyst consumer applies. It pulls in Kotlin JVM, kotlinx.serialization
     // and the application plugin. Resolving it here proves the published plugin marker works.
-    id("io.github.darkryh.katalyst") version "1.0.0-beta02"
+    id("io.github.darkryh.katalyst") version "1.0.0-beta03"
 }
 
 group = "com.example"
@@ -29,7 +29,7 @@ sourceSets.named("main").configure {
 // CRITICAL: not a single Ktor or Exposed coordinate appears here. Both arrive transitively through
 // the katalyst-* starters — that is the property this harness exists to prove.
 dependencies {
-    val katalyst = "1.0.0-beta02"
+    val katalyst = "1.0.0-beta03"
     implementation(platform("io.github.darkryh.katalyst:katalyst-bom:$katalyst"))
     implementation("io.github.darkryh.katalyst:katalyst-starter-web")
     implementation("io.github.darkryh.katalyst:katalyst-starter-persistence")

--- a/samples/katalyst-example/build.gradle.kts
+++ b/samples/katalyst-example/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
     // The single Katalyst plugin applies Kotlin JVM, kotlinx.serialization and the application
     // plugin. No version: it is resolved from the composite build (see settings.gradle.kts).
-    // A published consumer would write: id("io.github.darkryh.katalyst") version "1.0.0-beta02"
-    id("io.github.darkryh.katalyst") version "1.0.0-beta02"
+    // A published consumer would write: id("io.github.darkryh.katalyst") version "1.0.0-beta03"
+    id("io.github.darkryh.katalyst") version "1.0.0-beta03"
 }
 
 group = "io.github.darkryh"
@@ -13,7 +13,7 @@ application { mainClass = "io.github.darkryh.katalyst.example.ApplicationKt" }
 // Only katalyst-* artifacts — Ktor, Exposed, Koin, serialization, etc. all arrive transitively
 // through the starters. Pick the server engine by adding exactly one katalyst-starter-engine-*.
 dependencies {
-    val katalyst = "1.0.0-beta02"
+    val katalyst = "1.0.0-beta03"
     implementation(platform("io.github.darkryh.katalyst:katalyst-bom:$katalyst"))
     implementation("io.github.darkryh.katalyst:katalyst-starter-web")
     implementation("io.github.darkryh.katalyst:katalyst-starter-engine-netty")

--- a/web/initializr/build.gradle.kts
+++ b/web/initializr/build.gradle.kts
@@ -14,7 +14,7 @@ version = "1.0.0-SNAPSHOT"
 // so the published site tracks whatever release was just cut — alpha, beta, rc or stable. Falls back
 // to the current line for local and non-release builds.
 val katalystVersion: String =
-    (findProperty("katalystVersion") as String?)?.takeIf { it.isNotBlank() } ?: "1.0.0-beta02"
+    (findProperty("katalystVersion") as String?)?.takeIf { it.isNotBlank() } ?: "1.0.0-beta03"
 
 // Emits BuildInfo.KATALYST_VERSION into commonMain so StarterTemplate reads the injected value.
 val generateInitializrBuildInfo by tasks.registering {


### PR DESCRIPTION
Version bump only — no source changes. Same 8 files as `cb13071` (the beta02
cut): `gradle.properties` (what `release-library.yml` actually publishes), the
README and docs snippets, the initializr default, and the sample +
consumer-smoke consumer builds.

## What this release carries

- **Exposed 1.5.0**
- **`schema { createMissing() }` creates missing columns**, not just missing
  tables. `CREATE TABLE IF NOT EXISTS` skips an existing table whole, so a
  column added to a Kotlin `Table` after the first boot never reached the
  database — it surfaced as a SQL error on the first query that selected it.
  Strictly additive; opt out with `createMissing(createMissingColumns = false)`.
- **The TUI inspector can actually stop the backend.** `/shutdown` said "Stop
  the server and quit" and, run standalone, only closed the inspector. It now
  asks the backend over its loopback transport — the application stops *itself*
  through the same path SIGINT takes — and waits until it observes it stop.
  Gated on the same per-run token as `/snapshot`; disable with
  `-Dkatalyst.telemetry.shutdownControl=false`.
- **Dispatch 1.0.0-beta05** (released today), which fixes the intermittent
  crash when quitting the inspector and makes the command palette's selected
  row visible.

## Breaking (binary)

`SchemaManagementOptions` and `TelemetryConfig` each gained a constructor
parameter; `katalyst-core` and `katalyst-telemetry` gained public API.
Source-compatible for named/default-argument callers.

## Validated on this commit

- `./gradlew check` — green
- `samples/validate-samples.sh` — green (publishes to mavenLocal, then builds
  the sample as a real external consumer; the sample uses `createMissing()`,
  whose behaviour changed in this release)
- `harness/consumer-smoke/run-all-engines.sh` — green for netty, jetty and cio

## After merge

Tag `v1.0.0-beta03` to trigger `release-library.yml`. Publishing is
irreversible, so the tag goes on a commit whose CI is already green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
