### PR TITLE
fix(di): give the application a shutdown lifecycle, and tear down after it

### DIFF
--- a/config/katalyst-config-yaml/api/katalyst-config-yaml.api
+++ b/config/katalyst-config-yaml/api/katalyst-config-yaml.api
@@ -17,6 +17,7 @@ public final class io/github/darkryh/katalyst/config/yaml/YamlConfigurationFeatu
 	public synthetic fun <init> (Lio/github/darkryh/katalyst/core/config/ConfigProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getId ()Ljava/lang/String;
 	public fun onReady (Lio/github/darkryh/katalyst/di/feature/KatalystBeanContext;)V
+	public fun onShutdown (Lio/github/darkryh/katalyst/di/feature/KatalystBeanContext;)V
 	public fun provideBeanModules ()Ljava/util/List;
 }
 

--- a/data/katalyst-migrations/api/katalyst-migrations.api
+++ b/data/katalyst-migrations/api/katalyst-migrations.api
@@ -7,6 +7,7 @@ public final class io/github/darkryh/katalyst/migrations/feature/MigrationFeatur
 	public fun <init> (Lio/github/darkryh/katalyst/migrations/options/MigrationOptions;)V
 	public fun getId ()Ljava/lang/String;
 	public fun onReady (Lio/github/darkryh/katalyst/di/feature/KatalystBeanContext;)V
+	public fun onShutdown (Lio/github/darkryh/katalyst/di/feature/KatalystBeanContext;)V
 	public fun provideBeanModules ()Ljava/util/List;
 }
 

--- a/data/katalyst-persistence/api/katalyst-persistence.api
+++ b/data/katalyst-persistence/api/katalyst-persistence.api
@@ -90,6 +90,23 @@ public final class io/github/darkryh/katalyst/database/DatabasePoolSnapshot {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/github/darkryh/katalyst/database/DatabaseQuiesceResult {
+	public fun <init> (IIJZ)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()J
+	public final fun component4 ()Z
+	public final fun copy (IIJZ)Lio/github/darkryh/katalyst/database/DatabaseQuiesceResult;
+	public static synthetic fun copy$default (Lio/github/darkryh/katalyst/database/DatabaseQuiesceResult;IIJZILjava/lang/Object;)Lio/github/darkryh/katalyst/database/DatabaseQuiesceResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActiveAtEnd ()I
+	public final fun getActiveAtStart ()I
+	public final fun getDrained ()Z
+	public final fun getWaitedMillis ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/github/darkryh/katalyst/database/ManagedSqlExecutor : io/github/darkryh/katalyst/database/SqlExecutor {
 	public static final field Companion Lio/github/darkryh/katalyst/database/ManagedSqlExecutor$Companion;
 	public fun <init> (Ljavax/sql/DataSource;)V

--- a/data/katalyst-persistence/src/main/kotlin/io/github/darkryh/katalyst/database/DatabaseFactory.kt
+++ b/data/katalyst-persistence/src/main/kotlin/io/github/darkryh/katalyst/database/DatabaseFactory.kt
@@ -16,6 +16,9 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.vendors.currentDialectMetadata
 import org.slf4j.LoggerFactory
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Database factory for managing database connections with HikariCP connection pooling.
@@ -227,6 +230,69 @@ class DatabaseFactory private constructor(
     }
 
     /**
+     * Waits, for at most [timeout], until nothing is holding a pooled connection.
+     *
+     * The last line of defence in Katalyst's shutdown, and the only one that does not depend on the
+     * application having declared anything. [ShutdownHook][io.github.darkryh.katalyst.di.lifecycle]
+     * covers work that says how to stop itself, and running the application's teardown before this
+     * one covers work wired to Ktor's events — but a `job.cancel()` is not a `join()`, and a
+     * coroutine parked inside a blocking JDBC call does not observe cancellation until that call
+     * returns. Between "stop was requested" and "the driver came back" there is a window in which
+     * closing the pool severs a live socket, and the application sees `SQLSTATE 08006` from work it
+     * had already told to stop.
+     *
+     * So the pool is asked to go quiet before it is closed. In the ordinary case every connection is
+     * already back and this returns on the first check.
+     *
+     * Bounded on purpose. Waiting forever would trade a noisy shutdown for one that never finishes,
+     * and background work that is *still running* is not something this can fix — only report, which
+     * it does: the returned [DatabaseQuiesceResult] names how many connections were still checked
+     * out, and that is a far better diagnosis than the stack trace their next statement would throw.
+     *
+     * Never throws: it is called on the way out, where an exception can only make things worse.
+     */
+    @KatalystInternalApi
+    fun quiesce(timeout: Duration = DEFAULT_QUIESCE_TIMEOUT): DatabaseQuiesceResult {
+        val startedAt = System.nanoTime()
+        fun elapsedMillis() = (System.nanoTime() - startedAt) / 1_000_000
+
+        val activeAtStart = runCatching { activeConnections() }.getOrDefault(0)
+        if (closed.get() || activeAtStart == 0) {
+            return DatabaseQuiesceResult(activeAtStart, activeAtStart, elapsedMillis(), drained = activeAtStart == 0)
+        }
+
+        logger.debug("Waiting up to {} for {} active connection(s) to be returned", timeout, activeAtStart)
+        val deadlineNanos = startedAt + timeout.inWholeNanoseconds
+        var active = activeAtStart
+        while (active > 0 && System.nanoTime() < deadlineNanos) {
+            runCatching { Thread.sleep(QUIESCE_POLL_INTERVAL.inWholeMilliseconds) }
+                .onFailure {
+                    Thread.currentThread().interrupt()
+                    return DatabaseQuiesceResult(activeAtStart, active, elapsedMillis(), drained = false)
+                }
+            active = runCatching { activeConnections() }.getOrDefault(0)
+        }
+
+        val result = DatabaseQuiesceResult(activeAtStart, active, elapsedMillis(), drained = active == 0)
+        if (result.drained) {
+            logger.debug("Connection pool went quiet after {} ms", result.waitedMillis)
+        } else {
+            logger.warn(
+                "Connection pool still has {} active connection(s) after waiting {} ms - something is " +
+                    "still using the database during shutdown. Give that work a ShutdownHook so it is " +
+                    "stopped before the pool closes; otherwise its next statement will fail as the " +
+                    "pool goes away.",
+                result.activeAtEnd,
+                result.waitedMillis,
+            )
+        }
+        return result
+    }
+
+    private fun activeConnections(): Int =
+        if (dataSource.isClosed) 0 else dataSource.hikariPoolMXBean?.activeConnections ?: 0
+
+    /**
      * Closes the database connection and shuts down the connection pool.
      *
      * Should be called when the application shuts down to properly clean up resources.
@@ -269,6 +335,26 @@ class DatabaseFactory private constructor(
         }
     }
 }
+
+/**
+ * How long a shutdown waits for in-flight database work before the pool is closed anyway.
+ *
+ * Short: by the time this runs the application's own teardown has already been given its turn, so a
+ * connection still checked out means something is misbehaving, and the wait exists to make that
+ * case survivable rather than to accommodate it.
+ */
+private val DEFAULT_QUIESCE_TIMEOUT: Duration = 2.seconds
+
+/** How often [DatabaseFactory.quiesce] re-checks the pool while waiting. */
+private val QUIESCE_POLL_INTERVAL: Duration = 25.milliseconds
+
+/** What [DatabaseFactory.quiesce] observed. */
+data class DatabaseQuiesceResult(
+    val activeAtStart: Int,
+    val activeAtEnd: Int,
+    val waitedMillis: Long,
+    val drained: Boolean,
+)
 
 data class DatabasePoolSnapshot(
     val active: Int,

--- a/data/katalyst-persistence/src/test/kotlin/io/github/darkryh/katalyst/database/DatabaseQuiesceTest.kt
+++ b/data/katalyst-persistence/src/test/kotlin/io/github/darkryh/katalyst/database/DatabaseQuiesceTest.kt
@@ -5,10 +5,13 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.util.UUID
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -73,29 +76,43 @@ class DatabaseQuiesceTest {
     fun `returns straight away when nothing is using the pool`() {
         val factory = freshFactory()
 
-        val result = factory.quiesce(2.seconds)
+        // A long budget it must not spend: the assertion is "did not wait", with enough headroom
+        // that a slow machine cannot turn it into "waited a bit".
+        val result = factory.quiesce(30.seconds)
 
         assertTrue(result.drained)
         assertEquals(0, result.activeAtStart)
-        assertTrue(result.waitedMillis < 500, "waited ${result.waitedMillis} ms for an idle pool")
+        assertTrue(result.waitedMillis < 5_000, "waited ${result.waitedMillis} ms for an idle pool")
     }
 
     @Test
     fun `waits for an in-flight connection and returns once it is handed back`() {
+        // Driven by the connection's actual lifetime rather than by the clock. An earlier version
+        // released on a timer and asserted quiesce had waited at least that long, which is only true
+        // when the two threads are scheduled in the expected order - on a loaded machine the release
+        // can land before quiesce even looks, and the test fails for a reason unrelated to quiesce.
         val factory = freshFactory()
         val release = factory.holdAConnection()
 
-        Thread({
-            Thread.sleep(300)
-            release.countDown()
-        }, "quiesce-test-releaser").apply { isDaemon = true }.also { threads += it }.start()
+        val result = AtomicReference<DatabaseQuiesceResult?>(null)
+        val quiescing = Thread({ result.set(factory.quiesce(30.seconds)) }, "quiesce-under-test")
+            .apply { isDaemon = true }
+        threads += quiescing
+        quiescing.start()
 
-        val result = factory.quiesce(5.seconds)
+        // A connection is genuinely checked out and stays that way until this test says otherwise,
+        // so a correct quiesce cannot possibly be finished. Nothing here bounds how long it takes.
+        Thread.sleep(200)
+        assertTrue(quiescing.isAlive, "quiesce returned while a connection was still checked out")
+        assertNull(result.get())
 
-        assertTrue(result.drained, "the pool went quiet but quiesce did not notice")
-        assertTrue(result.activeAtStart >= 1, "the holder should have been counted as active")
-        assertEquals(0, result.activeAtEnd)
-        assertTrue(result.waitedMillis >= 250, "returned after ${result.waitedMillis} ms without waiting")
+        release.countDown()
+        quiescing.join(TimeUnit.SECONDS.toMillis(30))
+
+        val outcome = assertNotNull(result.get(), "quiesce never returned after the connection came back")
+        assertTrue(outcome.drained, "the pool went quiet but quiesce did not notice")
+        assertTrue(outcome.activeAtStart >= 1, "the holder should have been counted as active")
+        assertEquals(0, outcome.activeAtEnd)
     }
 
     @Test
@@ -120,10 +137,10 @@ class DatabaseQuiesceTest {
         val factory = freshFactory()
         factory.close()
 
-        val result = factory.quiesce(5.seconds)
+        val result = factory.quiesce(30.seconds)
 
         assertTrue(result.drained)
-        assertTrue(result.waitedMillis < 500)
+        assertTrue(result.waitedMillis < 5_000, "waited ${result.waitedMillis} ms on a closed factory")
     }
 
     @Test

--- a/data/katalyst-persistence/src/test/kotlin/io/github/darkryh/katalyst/database/DatabaseQuiesceTest.kt
+++ b/data/katalyst-persistence/src/test/kotlin/io/github/darkryh/katalyst/database/DatabaseQuiesceTest.kt
@@ -1,0 +1,138 @@
+package io.github.darkryh.katalyst.database
+
+import io.github.darkryh.katalyst.config.DatabaseConfig
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Pins [DatabaseFactory.quiesce] — the last thing standing between a still-busy background worker
+ * and a connection pool that is about to be closed underneath it.
+ *
+ * The guarantee is deliberately modest, and both halves of it matter: wait while the pool is still
+ * being used, and stop waiting when that stops being true or takes too long. A quiesce that never
+ * gave up would turn a noisy shutdown into one that never finishes.
+ */
+class DatabaseQuiesceTest {
+
+    private val factories = mutableListOf<DatabaseFactory>()
+    private val latches = mutableListOf<CountDownLatch>()
+    private val threads = mutableListOf<Thread>()
+
+    @AfterTest
+    fun tearDown() {
+        latches.forEach { it.countDown() }
+        threads.forEach { it.join(TimeUnit.SECONDS.toMillis(10)) }
+        factories.forEach { runCatching { it.close() } }
+        factories.clear()
+        latches.clear()
+        threads.clear()
+    }
+
+    private fun freshFactory(): DatabaseFactory =
+        DatabaseFactory.create(
+            DatabaseConfig(
+                url = "jdbc:h2:mem:quiesce_${UUID.randomUUID()};DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver",
+                username = "sa",
+                password = "",
+                maxPoolSize = 4,
+                minIdleConnections = 1,
+            )
+        ).also { factories += it }
+
+    /**
+     * Checks out a pooled connection and keeps it until the returned latch is released, the way an
+     * in-flight statement holds one during a shutdown.
+     */
+    private fun DatabaseFactory.holdAConnection(): CountDownLatch {
+        val release = CountDownLatch(1).also { latches += it }
+        val acquired = CountDownLatch(1)
+        val thread = Thread({
+            transaction(database) {
+                exec("SELECT 1")
+                acquired.countDown()
+                release.await(30, TimeUnit.SECONDS)
+            }
+        }, "quiesce-test-connection-holder").apply { isDaemon = true }
+        threads += thread
+        thread.start()
+        assertTrue(acquired.await(10, TimeUnit.SECONDS), "the holder never got a connection")
+        return release
+    }
+
+    @Test
+    fun `returns straight away when nothing is using the pool`() {
+        val factory = freshFactory()
+
+        val result = factory.quiesce(2.seconds)
+
+        assertTrue(result.drained)
+        assertEquals(0, result.activeAtStart)
+        assertTrue(result.waitedMillis < 500, "waited ${result.waitedMillis} ms for an idle pool")
+    }
+
+    @Test
+    fun `waits for an in-flight connection and returns once it is handed back`() {
+        val factory = freshFactory()
+        val release = factory.holdAConnection()
+
+        Thread({
+            Thread.sleep(300)
+            release.countDown()
+        }, "quiesce-test-releaser").apply { isDaemon = true }.also { threads += it }.start()
+
+        val result = factory.quiesce(5.seconds)
+
+        assertTrue(result.drained, "the pool went quiet but quiesce did not notice")
+        assertTrue(result.activeAtStart >= 1, "the holder should have been counted as active")
+        assertEquals(0, result.activeAtEnd)
+        assertTrue(result.waitedMillis >= 250, "returned after ${result.waitedMillis} ms without waiting")
+    }
+
+    @Test
+    fun `gives up at the timeout and reports what is still using the pool`() {
+        // The case the WARN exists for: something is still talking to the database and no amount of
+        // waiting will change that. Bounded, and honest about what it found.
+        val factory = freshFactory()
+        factory.holdAConnection()
+
+        val result = factory.quiesce(300.milliseconds)
+
+        assertFalse(result.drained)
+        assertTrue(result.activeAtEnd >= 1, "a connection is still checked out and must be reported")
+        assertTrue(
+            result.waitedMillis < 5_000,
+            "quiesce waited ${result.waitedMillis} ms past a 300 ms budget",
+        )
+    }
+
+    @Test
+    fun `is a no-op once the factory is closed`() {
+        val factory = freshFactory()
+        factory.close()
+
+        val result = factory.quiesce(5.seconds)
+
+        assertTrue(result.drained)
+        assertTrue(result.waitedMillis < 500)
+    }
+
+    @Test
+    fun `leaves the pool usable - it waits, it does not close anything`() {
+        val factory = freshFactory()
+
+        factory.quiesce(1.seconds)
+
+        assertEquals(1, transaction(factory.database) { exec("SELECT 1") { rs -> rs.next(); rs.getInt(1) } })
+        assertFalse(factory.poolSnapshot().closed)
+    }
+}

--- a/docs/reference/application-dsl.md
+++ b/docs/reference/application-dsl.md
@@ -155,18 +155,21 @@ katalystApplication(args) {
 
 ## Application lifecycle hooks
 
-Katalyst has two lifecycle hook interfaces. Implementing one is the only signal needed — a hook
+Katalyst has three lifecycle hook interfaces. Implementing one is the only signal needed — a hook
 is scanned, dependency-validated and constructor-injected on its own, and does **not** need to
-also implement `Component` or `Service`.
+also implement `Component` or `Service`. All three share `id` and `order`, declared on their common
+`LifecycleHook` supertype, so one class can implement several without restating either.
 
 - **`StartupHook`** — runs before the server binds, after all components are instantiated and
   the database schema is initialized. A built-in `StartupValidator` (`order = -100`) always
   runs first to verify database connectivity and schema.
 - **`ReadyHook`** — runs once the HTTP server is up and accepting traffic. Use it for runtime
   activations such as scheduler registration or background consumers.
+- **`ShutdownHook`** — runs while the application is shutting down, before Katalyst tears anything
+  down. Stop here whatever a `ReadyHook` started.
 
 Multiple hooks of each kind are allowed and run in deterministic order (`order` ascending,
-ties broken by qualified class name):
+ties broken by qualified class name). Shutdown walks the same numbers in reverse:
 
 ```kotlin
 class CacheWarmup(
@@ -188,6 +191,53 @@ class SchemaWarmupCheck : StartupHook {
     }
 }
 ```
+
+### Stopping background work
+
+Anything a `ReadyHook` starts has to be stopped again, and `ShutdownHook` is where. It runs while
+the framework is still completely usable — the connection pool is open, the container resolves, a
+final `transaction { }` works — and Katalyst **awaits** it before closing anything.
+
+That `suspend` matters. Ktor's own `ApplicationStopping` subscribers are ordinary synchronous
+functions, so a `job.cancel()` there returns immediately while the coroutine is still parked inside
+a blocking JDBC call. Cancelling is not joining:
+
+```kotlin
+class OutboxPublisher(private val outbox: OutboxRepository) : Service, ReadyHook, ShutdownHook {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var job: Job? = null
+
+    override val id = "outboxPublisher"
+    override val order = 60
+
+    override suspend fun onReady() {
+        job = scope.launch {
+            while (isActive) {
+                outbox.publishPending()
+                delay(200)
+            }
+        }
+    }
+
+    override suspend fun onShutdown() {
+        job?.cancelAndJoin()   // awaited: the in-flight pass finishes before the pool closes
+        scope.cancel()
+    }
+}
+```
+
+Shutdown proceeds in three steps, each finishing before the next begins:
+
+1. Ktor drains in-flight HTTP requests, then raises `ApplicationStopping` — application subscribers
+   run here, with the database still open.
+2. Katalyst runs every `ShutdownHook` in descending `order`, awaiting each one. A hook that throws is
+   logged and the rest still run; a hook that never returns is abandoned after a timeout so it cannot
+   hang the process.
+3. Katalyst stops its features, waits briefly for the connection pool to go quiet, and tears down.
+
+The wait in step 3 is a safety net for work that was cancelled but not joined, and it is bounded. If
+something is still holding a connection when it expires, Katalyst logs a warning naming how many —
+that is the signal that some background work needs a `ShutdownHook`.
 
 Hooks take part in the same dependency graph as components, so a hook whose constructor
 dependency cannot be resolved fails the bootstrap with a validation error naming the hook,

--- a/docs/reference/di-auto-wiring.md
+++ b/docs/reference/di-auto-wiring.md
@@ -14,7 +14,7 @@ Constructor parameters are resolved by type at instantiation.
 | A class implementing `CrudRepository<Id, Entity>` | A repository | `katalyst-persistence` |
 | An `object`/class implementing `Table<Id, Entity>` | A table | `katalyst-persistence` |
 | A class implementing `EventHandler<T>` | An event handler | `katalyst-events` |
-| A class implementing `StartupHook` or `ReadyHook` | A lifecycle hook (runs at startup, or once the server is ready) | `katalyst-di` |
+| A class implementing `StartupHook`, `ReadyHook` or `ShutdownHook` | A lifecycle hook (runs at startup, once the server is ready, or during shutdown) | `katalyst-di` |
 | A class implementing `KatalystMigration` | A migration | `katalyst-migrations` |
 | A class annotated `@ConfigPrefix`, or a class implementing `ConfigBinding` | A typed config binding | `katalyst-config-provider` |
 | `fun Route.xxx() = katalystRouting { … }` | A route module | `katalyst-ktor` |

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -36,7 +36,7 @@ itself adds no runtime classes.
 | Module | Purpose | Key API |
 |--------|---------|---------|
 | `katalyst-core` | Discovery interfaces and shared contracts | `Component`, `Service`, `ConfigProvider`, `Table`, `Validator` |
-| `katalyst-di` | Bootstrap, discovery, dependency analysis, lifecycle | `katalystApplication`, `KatalystFeature`, `StartupHook`, `ReadyHook`, `@InjectNamed` |
+| `katalyst-di` | Bootstrap, discovery, dependency analysis, lifecycle | `katalystApplication`, `KatalystFeature`, `StartupHook`, `ReadyHook`, `ShutdownHook`, `@InjectNamed` |
 | `katalyst-koin-bean` | Koin dependency-injection adapter | `KoinBeanEngine` |
 | `katalyst-scanner` | Classpath scanning that backs discovery | (internal; pulled in transitively) |
 

--- a/http/katalyst-websockets/api/katalyst-websockets.api
+++ b/http/katalyst-websockets/api/katalyst-websockets.api
@@ -3,6 +3,7 @@ public final class io/github/darkryh/katalyst/websockets/WebSocketFeature : io/g
 	public final fun configure (Lio/github/darkryh/katalyst/ktor/websocket/WebSocketOptions;)V
 	public fun getId ()Ljava/lang/String;
 	public fun onReady (Lio/github/darkryh/katalyst/di/feature/KatalystBeanContext;)V
+	public fun onShutdown (Lio/github/darkryh/katalyst/di/feature/KatalystBeanContext;)V
 	public fun provideBeanModules ()Ljava/util/List;
 }
 

--- a/katalyst-conventions/api/katalyst-conventions.api
+++ b/katalyst-conventions/api/katalyst-conventions.api
@@ -1,6 +1,7 @@
 public final class io/github/darkryh/katalyst/conventions/KatalystConventions {
 	public static final field APPLICATION_INITIALIZER Ljava/lang/String;
 	public static final field APPLICATION_READY_INITIALIZER Ljava/lang/String;
+	public static final field APPLICATION_SHUTDOWN_HOOK Ljava/lang/String;
 	public static final field COMPONENT Ljava/lang/String;
 	public static final field CONFIG_BINDING Ljava/lang/String;
 	public static final field CONFIG_PREFIX Ljava/lang/String;

--- a/katalyst-conventions/src/main/kotlin/io/github/darkryh/katalyst/conventions/KatalystConventions.kt
+++ b/katalyst-conventions/src/main/kotlin/io/github/darkryh/katalyst/conventions/KatalystConventions.kt
@@ -46,6 +46,8 @@ object KatalystConventions {
         "io.github.darkryh.katalyst.di.lifecycle.StartupHook"
     const val APPLICATION_READY_INITIALIZER: String =
         "io.github.darkryh.katalyst.di.lifecycle.ReadyHook"
+    const val APPLICATION_SHUTDOWN_HOOK: String =
+        "io.github.darkryh.katalyst.di.lifecycle.ShutdownHook"
     const val CONFIG_BINDING: String =
         "io.github.darkryh.katalyst.config.provider.ConfigBinding"
 
@@ -94,6 +96,7 @@ object KatalystConventions {
         KATALYST_MIGRATION,
         APPLICATION_INITIALIZER,
         APPLICATION_READY_INITIALIZER,
+        APPLICATION_SHUTDOWN_HOOK,
         CONFIG_BINDING,
     )
 

--- a/katalyst-di/api/katalyst-di.api
+++ b/katalyst-di/api/katalyst-di.api
@@ -644,6 +644,7 @@ public final class io/github/darkryh/katalyst/di/feature/EventSystemFeature : io
 	public fun <init> ()V
 	public fun getId ()Ljava/lang/String;
 	public fun onReady (Lio/github/darkryh/katalyst/di/feature/KatalystBeanContext;)V
+	public fun onShutdown (Lio/github/darkryh/katalyst/di/feature/KatalystBeanContext;)V
 	public fun provideBeanModules ()Ljava/util/List;
 }
 
@@ -701,11 +702,13 @@ public final class io/github/darkryh/katalyst/di/feature/KatalystBeanModuleBuild
 public abstract interface class io/github/darkryh/katalyst/di/feature/KatalystFeature {
 	public abstract fun getId ()Ljava/lang/String;
 	public fun onReady (Lio/github/darkryh/katalyst/di/feature/KatalystBeanContext;)V
+	public fun onShutdown (Lio/github/darkryh/katalyst/di/feature/KatalystBeanContext;)V
 	public fun provideBeanModules ()Ljava/util/List;
 }
 
 public final class io/github/darkryh/katalyst/di/feature/KatalystFeature$DefaultImpls {
 	public static fun onReady (Lio/github/darkryh/katalyst/di/feature/KatalystFeature;Lio/github/darkryh/katalyst/di/feature/KatalystBeanContext;)V
+	public static fun onShutdown (Lio/github/darkryh/katalyst/di/feature/KatalystFeature;Lio/github/darkryh/katalyst/di/feature/KatalystBeanContext;)V
 	public static fun provideBeanModules (Lio/github/darkryh/katalyst/di/feature/KatalystFeature;)Ljava/util/List;
 }
 
@@ -717,6 +720,7 @@ public final class io/github/darkryh/katalyst/di/feature/ServerConfigurationFeat
 	public static final field INSTANCE Lio/github/darkryh/katalyst/di/feature/ServerConfigurationFeature;
 	public fun getId ()Ljava/lang/String;
 	public fun onReady (Lio/github/darkryh/katalyst/di/feature/KatalystBeanContext;)V
+	public fun onShutdown (Lio/github/darkryh/katalyst/di/feature/KatalystBeanContext;)V
 	public fun provideBeanModules ()Ljava/util/List;
 }
 
@@ -813,6 +817,16 @@ public class io/github/darkryh/katalyst/di/lifecycle/LifecycleException : java/l
 	public fun getPhase ()Lio/github/darkryh/katalyst/di/lifecycle/LifecyclePhase;
 }
 
+public abstract interface class io/github/darkryh/katalyst/di/lifecycle/LifecycleHook {
+	public fun getId ()Ljava/lang/String;
+	public fun getOrder ()I
+}
+
+public final class io/github/darkryh/katalyst/di/lifecycle/LifecycleHook$DefaultImpls {
+	public static fun getId (Lio/github/darkryh/katalyst/di/lifecycle/LifecycleHook;)Ljava/lang/String;
+	public static fun getOrder (Lio/github/darkryh/katalyst/di/lifecycle/LifecycleHook;)I
+}
+
 public final class io/github/darkryh/katalyst/di/lifecycle/LifecyclePhase : java/lang/Enum {
 	public static final field COMPONENT_DISCOVERY Lio/github/darkryh/katalyst/di/lifecycle/LifecyclePhase;
 	public static final field DATABASE_VALIDATION Lio/github/darkryh/katalyst/di/lifecycle/LifecyclePhase;
@@ -834,9 +848,7 @@ public final class io/github/darkryh/katalyst/di/lifecycle/LifecycleStatusReport
 	public final fun snapshot ()Lio/github/darkryh/katalyst/di/lifecycle/StartupLifecycleReport;
 }
 
-public abstract interface class io/github/darkryh/katalyst/di/lifecycle/ReadyHook {
-	public fun getId ()Ljava/lang/String;
-	public fun getOrder ()I
+public abstract interface class io/github/darkryh/katalyst/di/lifecycle/ReadyHook : io/github/darkryh/katalyst/di/lifecycle/LifecycleHook {
 	public abstract fun onReady (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -865,9 +877,23 @@ public final class io/github/darkryh/katalyst/di/lifecycle/ServiceInitialization
 	public final fun getServiceName ()Ljava/lang/String;
 }
 
-public abstract interface class io/github/darkryh/katalyst/di/lifecycle/StartupHook {
-	public fun getId ()Ljava/lang/String;
-	public fun getOrder ()I
+public abstract interface class io/github/darkryh/katalyst/di/lifecycle/ShutdownHook : io/github/darkryh/katalyst/di/lifecycle/LifecycleHook {
+	public abstract fun onShutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/darkryh/katalyst/di/lifecycle/ShutdownHook$DefaultImpls {
+	public static fun getId (Lio/github/darkryh/katalyst/di/lifecycle/ShutdownHook;)Ljava/lang/String;
+	public static fun getOrder (Lio/github/darkryh/katalyst/di/lifecycle/ShutdownHook;)I
+}
+
+public final class io/github/darkryh/katalyst/di/lifecycle/ShutdownHookRegistry : io/github/darkryh/katalyst/di/registry/ResettableRegistry {
+	public static final field INSTANCE Lio/github/darkryh/katalyst/di/lifecycle/ShutdownHookRegistry;
+	public final fun getAll ()Ljava/util/List;
+	public final fun register (Lio/github/darkryh/katalyst/di/lifecycle/ShutdownHook;)V
+	public fun reset ()V
+}
+
+public abstract interface class io/github/darkryh/katalyst/di/lifecycle/StartupHook : io/github/darkryh/katalyst/di/lifecycle/LifecycleHook {
 	public abstract fun onStartup (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/KatalystApplication.kt
+++ b/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/KatalystApplication.kt
@@ -33,7 +33,7 @@ import io.github.darkryh.katalyst.di.lifecycle.StartupWarnings
 import io.github.darkryh.katalyst.di.lifecycle.BootstrapProgress
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationStarting
-import io.ktor.server.application.ApplicationStopping
+import io.ktor.server.application.ApplicationStopped
 import io.ktor.server.application.ServerReady
 import io.ktor.server.engine.ApplicationEngine
 import io.ktor.server.engine.EmbeddedServer
@@ -520,9 +520,9 @@ fun katalystApplication(
 
         // Ktor's application lifecycle events are raised per Application instance, not per process,
         // while Katalyst's bootstrap and teardown are process-wide. A dev-mode hot reload builds
-        // the replacement Application first and only then raises ApplicationStopping for the
-        // superseded one, so counting live instances is what tells a reload apart from a shutdown:
-        // a reload never drains the count, a real shutdown does.
+        // the replacement Application first and only then raises ApplicationStopping/Stopped for
+        // the superseded one, so counting live instances is what tells a reload apart from a
+        // shutdown: a reload never drains the count, a real shutdown does.
         val liveApplications = AtomicInteger()
 
         embeddedServer.monitor.subscribe(ApplicationStarting) { application ->
@@ -565,10 +565,23 @@ fun katalystApplication(
             )
         }
 
-        embeddedServer.monitor.subscribe(ApplicationStopping) {
+        // ApplicationStopped, NOT ApplicationStopping. Ktor's destroyApplication() runs
+        //     raise(ApplicationStopping) -> disposeAndJoin() -> raise(ApplicationStopped)
+        // and dispatches both to the same handler list in subscription order. Katalyst subscribes
+        // here, before start(), while an application's own KtorModules subscribe later - they are
+        // installed from inside the ApplicationStarting handler above. Tearing down on
+        // ApplicationStopping therefore closed the connection pool BEFORE the application's own
+        // stop-my-background-work handlers ran, and every one of them found a dead pool. Waiting for
+        // ApplicationStopped puts Katalyst last, where a framework belongs: the application gets the
+        // whole Stopping phase with everything still working, and only then is any of it taken away.
+        // Both events are raised inside EmbeddedServer.stop(), so this keeps the SIGINT property the
+        // previous placement was chosen for.
+        embeddedServer.monitor.subscribe(ApplicationStopped) {
             // A superseded Application leaving is a hot reload, not a shutdown: initializeDI() ran
             // once, before start(), so tearing Katalyst down here would close the pool, cancel the
-            // scheduler and reset the container with nothing left to bootstrap them again.
+            // scheduler and reset the container with nothing left to bootstrap them again. A reload
+            // raises Starting(new) before Stopped(old), so the count never drains and this still
+            // tells the two apart.
             if (liveApplications.decrementAndGet() > 0) {
                 logger.info("Ktor application instance replaced (reload) - Katalyst DI stays up")
                 return@subscribe
@@ -594,9 +607,10 @@ fun katalystApplication(
 
         // Publish how this application stops, so something inside the process can ask for it — today
         // the telemetry transport, on behalf of the inspector's `/shutdown`. Stopping the embedded
-        // server IS the shutdown: it releases start(wait = true), raises ApplicationStopping (which
-        // runs stopKatalystStandalone below) and then unwinds through the finally. That is the exact
-        // path SIGINT takes, so a requested shutdown and Ctrl+C are the same shutdown.
+        // server IS the shutdown: it releases start(wait = true), raises ApplicationStopping and
+        // then ApplicationStopped (which runs stopKatalystStandalone above) and then unwinds
+        // through the finally. That is the exact path SIGINT takes, so a requested shutdown and
+        // Ctrl+C are the same shutdown.
         ApplicationShutdown.install(description = "embedded server stop") {
             embeddedServer.stop(REQUESTED_SHUTDOWN_GRACE_MILLIS, REQUESTED_SHUTDOWN_TIMEOUT_MILLIS)
         }

--- a/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/config/DIConfiguration.kt
+++ b/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/config/DIConfiguration.kt
@@ -23,6 +23,7 @@ import io.github.darkryh.katalyst.di.lifecycle.BootstrapLifecycle
 import io.github.darkryh.katalyst.di.lifecycle.BootstrapProgress
 import io.github.darkryh.katalyst.di.lifecycle.StartupHookRunner
 import io.github.darkryh.katalyst.di.lifecycle.ReadyHookRunner
+import io.github.darkryh.katalyst.di.lifecycle.ShutdownHookRunner
 import io.github.darkryh.katalyst.di.lifecycle.StartupWarnings
 import io.github.darkryh.katalyst.di.lifecycle.StartupWarningsAggregator
 import io.github.darkryh.katalyst.di.module.coreDIModule
@@ -54,6 +55,17 @@ import kotlin.time.toDuration
  */
 private val logger = LoggerFactory.getLogger("DIConfiguration")
 private val shutdownLock = Any()
+
+/**
+ * The features this bootstrap installed, kept so the shutdown phase can stop them.
+ *
+ * Features are supplied to [initializeKatalystStandalone] and never reach the container, so without
+ * holding on to them here there is nothing left at teardown to call [KatalystFeature.onShutdown] on.
+ * Boot-scoped like every other global in [resetBootScopedGlobals]: cleared on both edges so one
+ * bootstrap can never stop another's features.
+ */
+@Volatile
+private var activeFeatures: List<KatalystFeature> = emptyList()
 
 /**
  * Configuration options for Katalyst dependency injection.
@@ -222,6 +234,9 @@ fun bootstrapKatalystContainer(
     }
 
     val beanContext = KatalystBeanContext(KatalystContainerProvider.current())
+    // Recorded before the ready hooks run: from here on a feature is live and has to be stopped,
+    // including when a later bootstrap phase throws and the entry point unwinds into teardown.
+    activeFeatures = features
     features.forEach { feature ->
         logger.debug("Executing onReady hook for feature '{}'", feature.id)
         feature.onReady(beanContext)
@@ -513,6 +528,7 @@ fun stopKatalystStandalone() {
         }
 
         try {
+            runShutdownPhase(engine)
             engine.stop()
         } finally {
             KatalystBeanEngines.clearActive()
@@ -545,10 +561,61 @@ private fun resetBootScopedGlobals() {
     // unwinds far enough to reach that finally. Leaving the action installed would advertise a
     // shutdown seam for a container that is already gone.
     ApplicationShutdown.uninstall()
+    activeFeatures = emptyList()
     RegistryManager.resetAll()
     GlobalEventHandlerRegistry.consumeAll()
     BootstrapProgress.clear()
     StartupWarnings.clear()
+}
+
+/**
+ * Stops everything the application owns, while everything the framework owns still works.
+ *
+ * This is the phase whose absence made shutdowns noisy. Katalyst used to go straight from "the
+ * server stopped" to closing the connection pool and unregistering the database, with application
+ * background work — the polling loops and queue consumers [ReadyHook] explicitly invites — still
+ * running. The pool would close under an in-flight statement and the shutdown would fill with
+ * `SQLSTATE 08006 / Socket closed` followed by `No transaction manager for db ExposedDatabase[...]`,
+ * from work the application had every intention of stopping and was simply never asked to.
+ *
+ * Three steps, narrowest contract first:
+ * 1. [ShutdownHook]s, awaited, so a worker can *join* what it cancelled rather than only signal it.
+ * 2. [KatalystFeature.onShutdown], in reverse installation order.
+ * 3. A bounded wait for the connection pool to go quiet, covering whatever declared neither.
+ *
+ * Nothing here may throw. Every step is a best effort whose failure is reported and stepped over,
+ * because the alternative — an exception escaping into [stopKatalystStandalone] — would skip the
+ * teardown that follows and leak the pool, the container and the engine.
+ */
+private fun runShutdownPhase(engine: KatalystBeanEngine) {
+    val container = engine.currentOrNull() ?: KatalystContainerProvider.currentOrNull()
+
+    runCatching {
+        runBlocking { ShutdownHookRunner(container).invokeAll() }
+    }.onFailure { error ->
+        logger.warn("Shutdown hook lifecycle failed: {}: {}", error::class.simpleName, error.message, error)
+    }
+
+    if (container != null) {
+        val beanContext = KatalystBeanContext(container)
+        // Reverse installation order, matching the hooks: a feature is stopped before the ones it
+        // was installed after, so nothing is torn down while something that needs it is still up.
+        activeFeatures.asReversed().forEach { feature ->
+            runCatching { feature.onShutdown(beanContext) }
+                .onFailure { error ->
+                    logger.warn(
+                        "Feature '{}' failed to stop: {}: {}",
+                        feature.id,
+                        error::class.simpleName,
+                        error.message,
+                        error,
+                    )
+                }
+        }
+    }
+
+    runCatching { container?.getOrNull<DatabaseFactory>()?.quiesce() }
+        .onFailure { error -> logger.debug("Could not wait for the connection pool to go quiet", error) }
 }
 
 fun runPreStartInitializers(container: KatalystContainer = KatalystContainerProvider.current()) {

--- a/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/extension/ExtensionPoint.kt
+++ b/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/extension/ExtensionPoint.kt
@@ -4,6 +4,7 @@ import io.github.darkryh.katalyst.conventions.KatalystConventions
 import io.github.darkryh.katalyst.core.component.Component
 import io.github.darkryh.katalyst.core.component.Service
 import io.github.darkryh.katalyst.di.lifecycle.ReadyHook
+import io.github.darkryh.katalyst.di.lifecycle.ShutdownHook
 import io.github.darkryh.katalyst.di.lifecycle.StartupHook
 import io.github.darkryh.katalyst.events.EventHandler
 import io.github.darkryh.katalyst.ktor.KtorModule
@@ -167,6 +168,14 @@ internal object ExtensionPoints {
         ExtensionPoint(
             id = "ready hooks",
             type = ReadyHook::class,
+            cardinality = Cardinality.MULTI,
+            optionalDiscovery = true,
+            joinsDependencyGraph = true,
+            registrationPhase = RegistrationPhase.WITH_COMPONENTS,
+        ),
+        ExtensionPoint(
+            id = "shutdown hooks",
+            type = ShutdownHook::class,
             cardinality = Cardinality.MULTI,
             optionalDiscovery = true,
             joinsDependencyGraph = true,

--- a/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/feature/KatalystFeature.kt
+++ b/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/feature/KatalystFeature.kt
@@ -27,6 +27,19 @@ interface KatalystFeature {
      * Optional hook executed after the bean container is fully initialized.
      */
     fun onReady(context: KatalystBeanContext) {}
+
+    /**
+     * Optional teardown, executed while the container and the connection pool are still alive.
+     *
+     * The counterpart to [onReady]. Until this existed a feature could only be torn down by the
+     * bean engine closing its `AutoCloseable` singletons, which happens after Katalyst has already
+     * begun dismantling itself — too late for anything that needs a working container, and with no
+     * say in the order.
+     *
+     * Failures are logged and the remaining features are still stopped: a shutdown that abandons
+     * the rest of its cleanup because one feature threw is worse than the throw.
+     */
+    fun onShutdown(context: KatalystBeanContext) {}
 }
 
 /**

--- a/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/internal/AutoBindingRegistrar.kt
+++ b/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/internal/AutoBindingRegistrar.kt
@@ -16,6 +16,8 @@ import io.github.darkryh.katalyst.di.lifecycle.StartupHook
 import io.github.darkryh.katalyst.di.lifecycle.StartupHookRegistry
 import io.github.darkryh.katalyst.di.lifecycle.ReadyHook
 import io.github.darkryh.katalyst.di.lifecycle.ReadyHookRegistry
+import io.github.darkryh.katalyst.di.lifecycle.ShutdownHook
+import io.github.darkryh.katalyst.di.lifecycle.ShutdownHookRegistry
 import io.github.darkryh.katalyst.di.invocation.CallableInvoker
 import io.github.darkryh.katalyst.di.invocation.ParameterResolver
 import io.github.darkryh.katalyst.di.invocation.getFromContainerOrNull
@@ -241,7 +243,7 @@ class AutoBindingRegistrar(
      *
      * **Reserved types (excluded):** [Any], [Table], and every framework marker in
      * [ExtensionPoints.reservedTypes] (Component, Service, CrudRepository, EventHandler,
-     * KtorModule, KatalystMigration, StartupHook, ReadyHook). Framework markers are bound
+     * KtorModule, KatalystMigration, StartupHook, ReadyHook, ShutdownHook). Framework markers are bound
      * separately — multibinding markers by [ExtensionPoints.multiBindingTypesOf] in
      * [registerInstance], which uses a runtime `isInstance` check so that markers reached
      * through an abstract intermediate are not missed the way this direct-supertype walk
@@ -606,8 +608,8 @@ class AutoBindingRegistrar(
      * If a secondary type is already bound to a different primary type, this method
      * throws a [DependencyInjectionException] to fail-fast on ambiguous bindings.
      *
-     * Selected lifecycle extension points (such as [StartupHook] and
-     * [ReadyHook]) are treated as multibinding types and are
+     * Selected lifecycle extension points (such as [StartupHook], [ReadyHook] and
+     * [ShutdownHook]) are treated as multibinding types and are
      * tracked via dedicated registries instead of Koin secondary key mappings.
      *
      * @param instance The component instance to register
@@ -669,6 +671,9 @@ class AutoBindingRegistrar(
         }
         if (instance is ReadyHook) {
             ReadyHookRegistry.register(instance)
+        }
+        if (instance is ShutdownHook) {
+            ShutdownHookRegistry.register(instance)
         }
 
         // Multibinding markers ARE registered as container secondary types. The container

--- a/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/internal/ComponentRegistrationOrchestrator.kt
+++ b/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/internal/ComponentRegistrationOrchestrator.kt
@@ -142,7 +142,7 @@ class ComponentRegistrationOrchestrator(
 
         // Discover each component type (methods are now internal - no reflection needed)
         // Lifecycle hooks are discovered as first-class categories: implementing
-        // StartupHook/ReadyHook alone is enough to be validated and constructor-injected,
+        // StartupHook/ReadyHook/ShutdownHook alone is enough to be validated and constructor-injected,
         // without also having to implement Component/Service.
         ExtensionPoints.all.forEach { extensionPoint ->
             val types = registrar.discoverConcreteTypes(extensionPoint.type.java)
@@ -448,7 +448,7 @@ class ComponentRegistrationOrchestrator(
         // Determine which base class this component implements.
         // Hook categories are checked last so a type that is both a Component/Service and a
         // lifecycle hook keeps its richer base class; registerInstance registers the hook
-        // side regardless, via its `is StartupHook` / `is ReadyHook` checks.
+        // side regardless, via its `is StartupHook` / `is ReadyHook` / `is ShutdownHook` checks.
         val baseClass = baseClassResolutionOrder
             .firstOrNull { componentType in discovered.types(it.id) }
             ?.type

--- a/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/lifecycle/LifecycleHook.kt
+++ b/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/lifecycle/LifecycleHook.kt
@@ -1,0 +1,29 @@
+package io.github.darkryh.katalyst.di.lifecycle
+
+/**
+ * What every Katalyst lifecycle hook has in common: a name for diagnostics, and a position relative
+ * to its peers.
+ *
+ * Declared once on a shared supertype because the object that starts something is usually the same
+ * object that stops it. [StartupHook], [ReadyHook] and [ShutdownHook] each used to carry their own
+ * `id`/`order` defaults, which meant the most ordinary shape in the framework — one class that boots
+ * a worker and shuts it down again — had to override both members for no reason other than Kotlin
+ * refusing to choose between two identical inherited defaults.
+ */
+interface LifecycleHook {
+    /**
+     * Stable identifier for logs and diagnostics.
+     */
+    val id: String
+        get() = this::class.simpleName ?: "LifecycleHook"
+
+    /**
+     * Position among sibling hooks of the same kind. Lower values run first on the way up.
+     *
+     * Shutdown walks the same numbers in reverse, so a hook is torn down before whatever it was
+     * ordered after was torn down — the usual "stop in the opposite order you started" rule, without
+     * a second number to keep in sync.
+     */
+    val order: Int
+        get() = 0
+}

--- a/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/lifecycle/ReadyHook.kt
+++ b/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/lifecycle/ReadyHook.kt
@@ -7,25 +7,16 @@ package io.github.darkryh.katalyst.di.lifecycle
  * Implementations should be used for background activations such as scheduler
  * jobs, consumers, and polling loops.
  *
+ * Whatever this hook starts should be stopped from the matching [ShutdownHook], which Katalyst
+ * awaits while the pool and the container are still alive. `id` and `order` come from
+ * [LifecycleHook], so one class can implement both without restating either.
+ *
  * **Discovery:**
  * Implementing this interface is sufficient. A hook is scanned, dependency-validated,
  * and constructor-injected on its own — it does NOT need to also implement
  * `Component` or `Service`.
  */
-interface ReadyHook {
-    /**
-     * Stable identifier for logs and diagnostics.
-     */
-    val id: String
-        get() = this::class.simpleName ?: "ReadyHook"
-
-    /**
-     * Ordering among ready hooks.
-     * Lower values execute first.
-     */
-    val order: Int
-        get() = 0
-
+interface ReadyHook : LifecycleHook {
     /**
      * Invoked when runtime is ready for traffic.
      */

--- a/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/lifecycle/ShutdownHook.kt
+++ b/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/lifecycle/ShutdownHook.kt
@@ -1,0 +1,58 @@
+package io.github.darkryh.katalyst.di.lifecycle
+
+/**
+ * Lifecycle hook that runs while the application is shutting down, BEFORE Katalyst tears anything
+ * down.
+ *
+ * This is the counterpart to [ReadyHook]. Whatever a ready hook started — a polling loop, a queue
+ * consumer, a scheduler job — is stopped here, and it is stopped while the framework is still
+ * completely usable: the connection pool is open, the container still resolves, and a final
+ * `transaction { }` still works.
+ *
+ * **Why this exists, and why it suspends.** Ktor's own `ApplicationStopping` subscribers are
+ * ordinary synchronous functions, so a worker's `job.cancel()` there returns *immediately* while the
+ * coroutine is still parked inside a blocking JDBC call. The pool then closes underneath it and the
+ * shutdown fills with `SQLSTATE 08006 / Socket closed` and
+ * `No transaction manager for db ExposedDatabase[...]`. [onShutdown] is a `suspend` function that
+ * Katalyst *awaits*, so the stop can be a real one:
+ *
+ * ```kotlin
+ * class AiRunQueueWorker(...) : Service, ReadyHook, ShutdownHook {
+ *     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+ *     private var queueJob: Job? = null
+ *
+ *     override suspend fun onReady() {
+ *         queueJob = scope.launch { while (isActive) { tick(); delay(200) } }
+ *     }
+ *
+ *     override suspend fun onShutdown() {
+ *         queueJob?.cancelAndJoin()   // awaited: the in-flight tick is finished before we return
+ *         scope.cancel()
+ *     }
+ * }
+ * ```
+ *
+ * **Discovery:** implementing this interface is sufficient. A hook is scanned, dependency-validated
+ * and constructor-injected on its own — it does NOT also need to be a `Component` or `Service`.
+ *
+ * **Order:** hooks run in DESCENDING [LifecycleHook.order], the reverse of startup, so a hook is
+ * stopped before the lower-ordered hooks it was started after.
+ *
+ * **Isolation:** a hook that throws is logged and the remaining hooks still run — a shutdown that
+ * abandons half its cleanup because one hook failed is worse than the failure. A hook that never
+ * returns is abandoned after a timeout so it cannot hang the process.
+ */
+interface ShutdownHook : LifecycleHook {
+    /**
+     * Invoked while the application is shutting down.
+     *
+     * At this point:
+     * - HTTP connectors are drained and closed ✓
+     * - the container, the connection pool and transactions all still work ✓
+     * - Katalyst has torn down nothing yet ✓
+     *
+     * Suspending work is awaited, so this is the place to *join* whatever was cancelled rather than
+     * only to signal it.
+     */
+    suspend fun onShutdown()
+}

--- a/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/lifecycle/ShutdownHookRegistry.kt
+++ b/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/lifecycle/ShutdownHookRegistry.kt
@@ -1,0 +1,28 @@
+package io.github.darkryh.katalyst.di.lifecycle
+
+import io.github.darkryh.katalyst.di.registry.RegistryManager
+import io.github.darkryh.katalyst.di.registry.ResettableRegistry
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Tracks [ShutdownHook] implementations discovered by auto-binding.
+ */
+object ShutdownHookRegistry : ResettableRegistry {
+    init {
+        RegistryManager.register(this)
+    }
+
+    private val hooks = CopyOnWriteArrayList<ShutdownHook>()
+
+    fun register(hook: ShutdownHook) {
+        if (hooks.none { it::class == hook::class }) {
+            hooks.add(hook)
+        }
+    }
+
+    fun getAll(): List<ShutdownHook> = hooks.toList()
+
+    override fun reset() {
+        hooks.clear()
+    }
+}

--- a/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/lifecycle/ShutdownHookRunner.kt
+++ b/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/lifecycle/ShutdownHookRunner.kt
@@ -1,0 +1,176 @@
+package io.github.darkryh.katalyst.di.lifecycle
+
+import io.github.darkryh.katalyst.core.di.KatalystContainer
+import io.github.darkryh.katalyst.core.di.getAll
+import io.github.darkryh.katalyst.di.internal.distinctByIdentity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * What [ShutdownHookRunner.invokeAll] did, for the caller to log and for tests to assert on.
+ */
+internal data class ShutdownHookReport(
+    val executed: Int,
+    val failed: List<String>,
+    val timedOut: List<String>,
+) {
+    val isClean: Boolean get() = failed.isEmpty() && timedOut.isEmpty()
+
+    companion object {
+        val NOTHING_TO_DO = ShutdownHookReport(executed = 0, failed = emptyList(), timedOut = emptyList())
+    }
+}
+
+/**
+ * Executes [ShutdownHook]s while the framework is still fully alive.
+ *
+ * Mirrors [ReadyHookRunner] deliberately — same two discovery sources, same identity dedup — with
+ * two differences that only matter on the way down:
+ *
+ * 1. **Reverse order.** Hooks run in descending [LifecycleHook.order], the exact reverse of startup.
+ * 2. **Nothing is allowed to hang or abort the shutdown.** A failing hook is logged and the rest
+ *    still run; a hook that never returns is abandoned after [hookTimeout]. Both are deliberate:
+ *    at this point in the lifecycle the process is leaving, and cleanup that gives up quietly is
+ *    strictly worse than cleanup that reports what it could not finish.
+ *
+ * Each hook runs as its own job so the timeout can actually take effect. Awaiting the hook inline
+ * would not work: a hook blocked in a JDBC call cannot observe cancellation, so `withTimeoutOrNull`
+ * around the call itself would still wait for it. Joining a separate job is cancellable, so a stuck
+ * hook costs [hookTimeout] and not the whole shutdown.
+ */
+internal class ShutdownHookRunner(
+    private val container: KatalystContainer?,
+    private val hookTimeout: Duration = DEFAULT_HOOK_TIMEOUT,
+) {
+    private val logger = LoggerFactory.getLogger("ShutdownHookRunner")
+
+    suspend fun invokeAll(): ShutdownHookReport {
+        val hooks = discoverHooks()
+        if (hooks.isEmpty()) {
+            logger.debug("Shutdown hook lifecycle: no hooks registered")
+            return ShutdownHookReport.NOTHING_TO_DO
+        }
+
+        logger.info("Shutdown hook lifecycle starting: {} hook(s)", hooks.size)
+        val failed = mutableListOf<String>()
+        val timedOut = mutableListOf<String>()
+        // Not the caller's scope: a hook that never returns must not keep this scope from being
+        // left behind, and cancelling at the end is the only pressure we can put on one.
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            hooks.forEach { hook -> runHook(scope, hook, failed, timedOut) }
+        } finally {
+            scope.cancel()
+        }
+
+        val report = ShutdownHookReport(hooks.size, failed, timedOut)
+        if (report.isClean) {
+            logger.info("Shutdown hook lifecycle completed: {} hook(s)", hooks.size)
+        } else {
+            logger.warn(
+                "Shutdown hook lifecycle completed with problems: {} hook(s), failed={}, timed out={}",
+                hooks.size,
+                failed,
+                timedOut,
+            )
+        }
+        return report
+    }
+
+    private suspend fun runHook(
+        scope: CoroutineScope,
+        hook: ShutdownHook,
+        failed: MutableList<String>,
+        timedOut: MutableList<String>,
+    ) {
+        val startTime = System.currentTimeMillis()
+        logger.debug("Shutdown hook starting: {}", hook.id)
+
+        val failure = AtomicReference<Throwable?>(null)
+        val job = scope.launch {
+            runCatching { hook.onShutdown() }.onFailure(failure::set)
+        }
+
+        val completed = withTimeoutOrNull(hookTimeout) { job.join() } != null
+        val duration = System.currentTimeMillis() - startTime
+
+        when {
+            !completed -> {
+                timedOut += hook.id
+                job.cancel()
+                logger.warn(
+                    "Shutdown hook did not finish within {} and was abandoned: {} - the shutdown " +
+                        "continues, but whatever it owns was not stopped cleanly",
+                    hookTimeout,
+                    hook.id,
+                )
+            }
+
+            failure.get() != null -> {
+                failed += hook.id
+                // Logged here and not left to the caller: Ktor swallows exceptions thrown out of
+                // its shutdown events at debug level, so an unlogged failure here is an invisible one.
+                logger.error(
+                    "Shutdown hook failed: {} ({} ms) - {}",
+                    hook.id,
+                    duration,
+                    failure.get()?.message,
+                    failure.get(),
+                )
+            }
+
+            else -> logger.debug("Shutdown hook completed: {} ({} ms)", hook.id, duration)
+        }
+    }
+
+    private fun discoverHooks(): List<ShutdownHook> {
+        val registryHooks = ShutdownHookRegistry.getAll()
+        // Same reasoning as ReadyHookRunner: a container-side failure must not silently reduce the
+        // hook set. Losing a shutdown hook means background work keeps running into the teardown.
+        val containerHooks = container?.let { active ->
+            runCatching { active.getAll<ShutdownHook>() }
+                .onFailure { error ->
+                    logger.warn(
+                        "Could not enumerate {} beans from the container; only the {} hook(s) already " +
+                            "held by ShutdownHookRegistry will run. Reason: {}: {}",
+                        ShutdownHook::class.simpleName,
+                        registryHooks.size,
+                        error::class.simpleName,
+                        error.message,
+                        error,
+                    )
+                }
+                .getOrElse { emptyList() }
+        }.orEmpty()
+
+        return (registryHooks + containerHooks)
+            .distinctByIdentity()
+            .sortedWith(shutdownHookOrderComparator)
+    }
+
+    private companion object {
+        /**
+         * How long one hook may take before the shutdown stops waiting for it.
+         *
+         * Per hook rather than a shared budget, so a slow drain does not eat the allowance of the
+         * hooks queued behind it and the log names exactly which one overran.
+         */
+        val DEFAULT_HOOK_TIMEOUT: Duration = 10.seconds
+    }
+}
+
+/**
+ * The exact reverse of [readyHookOrderComparator], tie-break included, so stop order mirrors start
+ * order even between hooks that share a number.
+ */
+internal val shutdownHookOrderComparator: Comparator<ShutdownHook> =
+    compareByDescending<ShutdownHook> { it.order }
+        .thenByDescending { it::class.qualifiedName ?: it::class.simpleName ?: "" }

--- a/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/lifecycle/StartupHook.kt
+++ b/katalyst-di/src/main/kotlin/io/github/darkryh/katalyst/di/lifecycle/StartupHook.kt
@@ -28,26 +28,11 @@ package io.github.darkryh.katalyst.di.lifecycle
  *
  * Runtime activations (scheduler, background consumers) should use
  * [ReadyHook], not this interface.
+ *
+ * `id` and `order` come from [LifecycleHook]. The standard order values here are
+ * `StartupValidator` at -100 (always first) and custom pre-start hooks at 0 or above.
  */
-interface StartupHook {
-    /**
-     * Unique identifier for this hook.
-     * Used for logging and debugging.
-     */
-    val id: String
-        get() = this::class.simpleName ?: "StartupHook"
-
-    /**
-     * Execution order relative to other hooks.
-     * Lower numbers execute first.
-     *
-     * Standard values:
-     * - StartupValidator: -100 (always first)
-     * - Custom pre-start hooks: 0+ (default, in any order)
-     */
-    val order: Int
-        get() = 0
-
+interface StartupHook : LifecycleHook {
     /**
      * Invoked when this hook's turn comes during startup.
      *

--- a/katalyst-di/src/test/kotlin/io/github/darkryh/katalyst/di/ShutdownPhaseOrderingTest.kt
+++ b/katalyst-di/src/test/kotlin/io/github/darkryh/katalyst/di/ShutdownPhaseOrderingTest.kt
@@ -1,0 +1,470 @@
+package io.github.darkryh.katalyst.di
+
+import io.github.darkryh.katalyst.config.DatabaseConfig
+import io.github.darkryh.katalyst.core.di.KatalystContainerProvider
+import io.github.darkryh.katalyst.database.DatabaseFactory
+import io.github.darkryh.katalyst.di.config.ApplicationConfigProvider
+import io.github.darkryh.katalyst.di.config.stopKatalystStandalone
+import io.github.darkryh.katalyst.di.feature.KatalystBeanContext
+import io.github.darkryh.katalyst.di.feature.KatalystFeature
+import io.github.darkryh.katalyst.di.internal.KtorModuleRegistry
+import io.github.darkryh.katalyst.di.lifecycle.ReadyHook
+import io.github.darkryh.katalyst.di.lifecycle.ReadyHookRegistry
+import io.github.darkryh.katalyst.di.lifecycle.ShutdownHook
+import io.github.darkryh.katalyst.di.lifecycle.ShutdownHookRegistry
+import io.github.darkryh.katalyst.di.registry.RegistryManager
+import io.github.darkryh.katalyst.di.test.TestBeanEngine
+import io.github.darkryh.katalyst.ktor.KtorModule
+import io.ktor.events.Events
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationEnvironment
+import io.ktor.server.application.ApplicationStopping
+import io.ktor.server.application.ServerReady
+import io.ktor.server.application.serverConfig
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.engine.ApplicationEngine
+import io.ktor.server.engine.ApplicationEngineFactory
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.EngineConnectorConfig
+import io.ktor.util.logging.KtorSimpleLogger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The regression test for the defect this whole phase exists to fix.
+ *
+ * Katalyst used to tear itself down from Ktor's `ApplicationStopping`, and because it subscribes
+ * before `start()` while an application's own modules subscribe during it, Katalyst always went
+ * first. The connection pool closed while application background work — the polling loops
+ * [ReadyHook] explicitly invites — was still querying, and a shutdown produced
+ * `SQLSTATE 08006 / Socket closed` followed by
+ * `IllegalStateException: No transaction manager for db ExposedDatabase[...]`.
+ *
+ * Everything below is one shape: boot a real application with a worker polling the database as fast
+ * as it can, shut it down, and require that **not one query failed**. That is the only assertion that
+ * actually pins the fix, because the bug is a race — an ordering assertion alone would pass on a
+ * lucky run.
+ */
+class ShutdownPhaseOrderingTest {
+
+    private val pollFailures = CopyOnWriteArrayList<String>()
+    private val pollsCompleted = AtomicInteger()
+    private val stoppingSawUsableDatabase = AtomicReference<Boolean?>(null)
+    private val shutdownHookSawUsableDatabase = AtomicReference<Boolean?>(null)
+    private val featureStopped = AtomicBoolean(false)
+    private val featureReadyRan = AtomicBoolean(false)
+    private val readyHookRan = AtomicBoolean(false)
+    private val workers = CopyOnWriteArrayList<PollingWorker>()
+
+    private var applicationThread: Thread? = null
+    private var server: EmbeddedServer<ApplicationEngine, ApplicationEngine.Configuration>? = null
+    private val bootFailure = AtomicReference<Throwable?>(null)
+    private val listening = CountDownLatch(1)
+
+    @BeforeTest
+    fun setUp() {
+        RegistryManager.resetAll()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        runCatching { server?.stop(0, 5_000) }
+        applicationThread?.join(TimeUnit.SECONDS.toMillis(30))
+        workers.forEach { it.forceStop() }
+        workers.clear()
+        stopKatalystStandalone()
+        RegistryManager.resetAll()
+    }
+
+    @Test
+    fun `background work started by a ReadyHook never sees a closed pool`() {
+        bootAndShutDown()
+
+        assertTrue(
+            pollsCompleted.get() > 0,
+            "the worker never ran, so this proves nothing - it has to have been polling at shutdown",
+        )
+        assertEquals(
+            emptyList(),
+            pollFailures.toList(),
+            "background work must not outlive the database it was told to stop using",
+        )
+    }
+
+    @Test
+    fun `an ApplicationStopping subscriber still has a working database`() {
+        // The Ktor-native idiom, and the one real applications already use. It runs before Katalyst
+        // touches anything now, so a consumer that stops its workers there finds the pool intact.
+        bootAndShutDown()
+
+        assertEquals(true, stoppingSawUsableDatabase.get(), "ApplicationStopping ran after the teardown")
+    }
+
+    @Test
+    fun `a ShutdownHook still has a working database`() {
+        bootAndShutDown()
+
+        assertEquals(
+            true,
+            shutdownHookSawUsableDatabase.get(),
+            "a shutdown hook has to be able to do final database work - that is the point of running " +
+                "it before the teardown rather than after",
+        )
+    }
+
+    @Test
+    fun `features are stopped as part of the shutdown phase`() {
+        bootAndShutDown()
+
+        assertTrue(featureStopped.get(), "KatalystFeature.onShutdown was never called")
+    }
+
+    @Test
+    fun `the teardown still completes - the container is gone afterwards`() {
+        bootAndShutDown()
+
+        assertEquals(null, KatalystContainerProvider.currentOrNull())
+    }
+
+    @Test
+    fun `repeated boot and shutdown cycles never produce a failed query`() {
+        // The anti-regression that matters. The defect was probabilistic - whether a tick happened to
+        // be in flight in the few milliseconds between two handlers - so a single clean shutdown is
+        // not evidence. Every iteration starts a worker hammering the database and stops it.
+        repeat(CYCLES) { iteration ->
+            reset()
+            bootAndShutDown()
+            assertTrue(
+                pollsCompleted.get() > 0,
+                "iteration $iteration never polled, so it did not exercise the race",
+            )
+            assertEquals(
+                emptyList(),
+                pollFailures.toList(),
+                "iteration $iteration lost a query to the shutdown",
+            )
+        }
+    }
+
+    private fun reset() {
+        runCatching { server?.stop(0, 5_000) }
+        applicationThread?.join(TimeUnit.SECONDS.toMillis(30))
+        workers.forEach { it.forceStop() }
+        workers.clear()
+        stopKatalystStandalone()
+        RegistryManager.resetAll()
+        pollFailures.clear()
+        pollsCompleted.set(0)
+        stoppingSawUsableDatabase.set(null)
+        shutdownHookSawUsableDatabase.set(null)
+        featureStopped.set(false)
+        bootFailure.set(null)
+        applicationThread = null
+        server = null
+    }
+
+    /** Boots a real application with a database-polling worker, then stops it the way SIGINT does. */
+    private fun bootAndShutDown() {
+        val release = CountDownLatch(1)
+        val started = CountDownLatch(1)
+        val embedded = buildServer(started, release)
+        server = embedded
+
+        val thread = Thread({
+            runCatching {
+                katalystApplication {
+                    configuration(deploymentConfiguration())
+                    database(inMemoryDb())
+                    beanEngine(TestBeanEngine())
+                    engine(embedded)
+                    features { feature(ProbeFeature(this@ShutdownPhaseOrderingTest)) }
+                }
+            }.onFailure(bootFailure::set)
+        }, "shutdown-phase-test").apply { isDaemon = true }
+        applicationThread = thread
+        thread.start()
+
+        // Wait in slices so a bootstrap that threw surfaces its own exception immediately instead of
+        // being reported thirty seconds later as "never started".
+        var reachedStart = false
+        repeat(BOOT_WAIT_SLICES) {
+            if (started.await(BOOT_WAIT_SLICE_MILLIS, TimeUnit.MILLISECONDS)) {
+                reachedStart = true
+                return@repeat
+            }
+            bootFailure.get()?.let { throw it }
+        }
+        bootFailure.get()?.let { throw it }
+        assertTrue(reachedStart, "the application never reached the engine start")
+
+        // Let the worker get into its loop so a query really is in flight around the shutdown.
+        Thread.sleep(POLL_WARMUP_MILLIS)
+        assertTrue(
+            pollsCompleted.get() > 0 || pollFailures.isNotEmpty(),
+            "the worker never started: featureReady=${featureReadyRan.get()} " +
+                "readyHook=${readyHookRan.get()} polls=${pollsCompleted.get()} " +
+                "failures=${pollFailures.toList()}",
+        )
+
+        embedded.stop(0, 5_000)
+        thread.join(TimeUnit.SECONDS.toMillis(30))
+        bootFailure.get()?.let { throw it }
+        assertFalse(thread.isAlive, "the application never came out of start(wait = true)")
+        settle()
+    }
+
+    /**
+     * Waits until the worker is observably finished, or until it proves it is not.
+     *
+     * Without this the assertions race the worker instead of testing it: the teardown has happened
+     * by the time the application thread joins, but a worker that was NOT stopped is most likely
+     * parked in its inter-poll delay at that instant and has not yet touched the closed pool. Waiting
+     * for it to either stop or fail is what makes "no query failed" mean something in both directions.
+     */
+    private fun settle() {
+        val worker = workers.lastOrNull() ?: return
+        val deadlineNanos = System.nanoTime() + SETTLE_TIMEOUT_MILLIS * 1_000_000
+        while (worker.isRunning() && pollFailures.isEmpty() && System.nanoTime() < deadlineNanos) {
+            Thread.sleep(SETTLE_POLL_MILLIS)
+        }
+        assertFalse(
+            worker.isRunning(),
+            "the shutdown phase never stopped the worker - it is still querying after teardown",
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun buildServer(
+        started: CountDownLatch,
+        release: CountDownLatch,
+    ): EmbeddedServer<ApplicationEngine, ApplicationEngine.Configuration> {
+        val environment = ShutdownPhaseTestEnvironment()
+        val rootConfig = serverConfig(environment) { watchPaths = emptyList() }
+        return EmbeddedServer(rootConfig, ParkingEngineFactory(started, release)) { }
+            as EmbeddedServer<ApplicationEngine, ApplicationEngine.Configuration>
+    }
+
+    private fun deploymentConfiguration() = ApplicationConfigProvider(
+        MapApplicationConfig(
+            "ktor.deployment.host" to "127.0.0.1",
+            "ktor.deployment.port" to "8080",
+            "ktor.deployment.shutdownGracePeriod" to "1000",
+            "ktor.deployment.shutdownTimeout" to "5000",
+            "ktor.deployment.connectionGroupSize" to "1",
+            "ktor.deployment.workerGroupSize" to "1",
+            "ktor.deployment.callGroupSize" to "1",
+            "ktor.deployment.maxInitialLineLength" to "4096",
+            "ktor.deployment.maxHeaderSize" to "8192",
+            "ktor.deployment.maxChunkSize" to "8192",
+            "ktor.deployment.connectionIdleTimeoutMs" to "180000",
+        )
+    )
+
+    private fun inMemoryDb() = DatabaseConfig(
+        url = "jdbc:h2:mem:shutdown-phase-${UUID.randomUUID()};DB_CLOSE_DELAY=-1",
+        driver = "org.h2.Driver",
+        username = "sa",
+        password = "",
+        maxPoolSize = 4,
+        minIdleConnections = 1,
+        connectionTimeout = 3000,
+        idleTimeout = 10000,
+        maxLifetime = 30000,
+        autoCommit = false,
+        transactionIsolation = "TRANSACTION_REPEATABLE_READ",
+    )
+
+    /**
+     * Everything the probe needs to observe, handed to the test doubles that live outside the class.
+     */
+    internal fun recordPollSuccess() = pollsCompleted.incrementAndGet()
+    internal fun recordPollFailure(message: String) { pollFailures += message }
+    internal fun recordStoppingObservation(usable: Boolean) = stoppingSawUsableDatabase.set(usable)
+    internal fun recordShutdownHookObservation(usable: Boolean) = shutdownHookSawUsableDatabase.set(usable)
+    internal fun recordFeatureStopped() = featureStopped.set(true)
+    internal fun recordFeatureReady() = featureReadyRan.set(true)
+    internal fun recordReadyHookRan() = readyHookRan.set(true)
+    internal fun trackWorker(worker: PollingWorker) { workers += worker }
+
+    private companion object {
+        const val CYCLES = 12
+        const val BOOT_WAIT_SLICES = 100
+        const val BOOT_WAIT_SLICE_MILLIS = 200L
+        const val POLL_WARMUP_MILLIS = 150L
+        const val SETTLE_TIMEOUT_MILLIS = 3_000L
+        const val SETTLE_POLL_MILLIS = 10L
+    }
+}
+
+/**
+ * Registers the probe's worker and Ktor module once the container exists.
+ *
+ * A feature rather than component scanning because [bootstrapKatalystContainer] resets every
+ * registry as its first act, so anything registered before boot would be wiped. `onReady` runs after
+ * that reset and before the ready-hook lifecycle, which is exactly where a real feature contributes.
+ */
+private class ProbeFeature(private val test: ShutdownPhaseOrderingTest) : KatalystFeature {
+    override val id: String = "shutdown-phase-probe"
+
+    override fun onReady(context: KatalystBeanContext) {
+        test.recordFeatureReady()
+        val databaseFactory = context.get<DatabaseFactory>()
+        val worker = PollingWorker(test, databaseFactory)
+        test.trackWorker(worker)
+        ReadyHookRegistry.register(worker)
+        ShutdownHookRegistry.register(worker)
+        KtorModuleRegistry.register(StoppingObserverModule(test, databaseFactory))
+    }
+
+    override fun onShutdown(context: KatalystBeanContext) {
+        test.recordFeatureStopped()
+    }
+}
+
+/**
+ * A background worker in the shape the framework invites: started from [ReadyHook], owning its own
+ * scope, polling the database on a tight loop, stopped from [ShutdownHook] with a real join.
+ */
+internal class PollingWorker(
+    private val test: ShutdownPhaseOrderingTest,
+    private val databaseFactory: DatabaseFactory,
+) : ReadyHook, ShutdownHook {
+
+    override val id: String = "polling-worker"
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var job: Job? = null
+
+    override suspend fun onReady() {
+        test.recordReadyHookRan()
+        job = scope.launch {
+            while (isActive) {
+                runCatching {
+                    // Several statements per pass, like a real tick that refreshes gauges, sweeps
+                    // stale rows and claims work. It keeps a connection checked out for most of the
+                    // loop, which is what makes the shutdown race reproducible rather than lucky.
+                    transaction(databaseFactory.database) {
+                        repeat(QUERIES_PER_POLL) { exec("SELECT 1") { row -> row.next() } }
+                    }
+                }
+                    .onSuccess { test.recordPollSuccess() }
+                    .onFailure { error -> test.recordPollFailure("${error::class.simpleName}: ${error.message}") }
+                delay(POLL_INTERVAL_MILLIS)
+            }
+        }
+    }
+
+    override suspend fun onShutdown() {
+        // cancelAndJoin, not cancel: a cancel alone returns while the loop is still inside a blocking
+        // JDBC call, which is precisely how the original defect survived a correctly ordered stop.
+        job?.cancelAndJoin()
+        job = null
+        scope.cancel()
+        test.recordShutdownHookObservation(canQuery())
+    }
+
+    /** Whether the poll loop is still alive - the shutdown phase is supposed to have ended it. */
+    fun isRunning(): Boolean = job?.isActive == true
+
+    /** Last-resort cleanup if a test fails before the shutdown phase runs. */
+    fun forceStop() {
+        job?.cancel()
+        job = null
+        runCatching { scope.cancel() }
+    }
+
+    private fun canQuery(): Boolean =
+        runCatching { transaction(databaseFactory.database) { exec("SELECT 1") { it.next() } } }.isSuccess
+
+    private companion object {
+        const val POLL_INTERVAL_MILLIS = 1L
+        const val QUERIES_PER_POLL = 40
+    }
+}
+
+/** The Ktor-native teardown idiom, observed from the inside. */
+private class StoppingObserverModule(
+    private val test: ShutdownPhaseOrderingTest,
+    private val databaseFactory: DatabaseFactory,
+) : KtorModule {
+    override val order: Int = -1_000
+
+    override fun install(application: Application) {
+        application.monitor.subscribe(ApplicationStopping) {
+            val usable = runCatching {
+                transaction(databaseFactory.database) { exec("SELECT 1") { it.next() } }
+            }.isSuccess
+            test.recordStoppingObservation(usable && !databaseFactory.poolSnapshot().closed)
+        }
+    }
+}
+
+private class ShutdownPhaseTestEnvironment : ApplicationEnvironment {
+    override val classLoader: ClassLoader = Thread.currentThread().contextClassLoader
+    override val log = KtorSimpleLogger("ShutdownPhaseOrderingTest")
+    override val config = MapApplicationConfig()
+
+    @Deprecated("Use Application.monitor", level = DeprecationLevel.WARNING)
+    override val monitor: Events = Events()
+}
+
+/** Parks in `start(wait = true)` like a real engine and releases that park when stopped. */
+private class ParkingEngine(
+    override val environment: ApplicationEnvironment,
+    private val monitor: Events,
+    private val started: CountDownLatch,
+    private val release: CountDownLatch,
+) : ApplicationEngine {
+
+    override fun start(wait: Boolean): ApplicationEngine {
+        monitor.raise(ServerReady, environment)
+        started.countDown()
+        if (wait) release.await(60, TimeUnit.SECONDS)
+        return this
+    }
+
+    override fun stop(gracePeriodMillis: Long, timeoutMillis: Long) {
+        release.countDown()
+    }
+
+    override suspend fun resolvedConnectors(): List<EngineConnectorConfig> = emptyList()
+}
+
+private class ParkingEngineFactory(
+    private val started: CountDownLatch,
+    private val release: CountDownLatch,
+) : ApplicationEngineFactory<ParkingEngine, ApplicationEngine.Configuration> {
+
+    override fun configuration(
+        configure: ApplicationEngine.Configuration.() -> Unit
+    ): ApplicationEngine.Configuration = ApplicationEngine.Configuration().apply(configure)
+
+    override fun create(
+        environment: ApplicationEnvironment,
+        monitor: Events,
+        developmentMode: Boolean,
+        configuration: ApplicationEngine.Configuration,
+        applicationProvider: () -> Application,
+    ): ParkingEngine = ParkingEngine(environment, monitor, started, release)
+}

--- a/katalyst-di/src/test/kotlin/io/github/darkryh/katalyst/di/ShutdownPhaseOrderingTest.kt
+++ b/katalyst-di/src/test/kotlin/io/github/darkryh/katalyst/di/ShutdownPhaseOrderingTest.kt
@@ -218,11 +218,17 @@ class ShutdownPhaseOrderingTest {
         bootFailure.get()?.let { throw it }
         assertTrue(reachedStart, "the application never reached the engine start")
 
-        // Let the worker get into its loop so a query really is in flight around the shutdown.
-        Thread.sleep(POLL_WARMUP_MILLIS)
+        // Wait for the worker to have actually completed a pass, rather than sleeping a fixed
+        // interval and hoping. A pass is forty statements, and on a loaded CI runner that took
+        // longer than a hand-picked sleep allowed - which made this an assertion about the runner's
+        // speed instead of about the shutdown.
+        val warmupDeadlineNanos = System.nanoTime() + POLL_WARMUP_TIMEOUT_MILLIS * 1_000_000
+        while (pollsCompleted.get() == 0 && pollFailures.isEmpty() && System.nanoTime() < warmupDeadlineNanos) {
+            Thread.sleep(SETTLE_POLL_MILLIS)
+        }
         assertTrue(
             pollsCompleted.get() > 0 || pollFailures.isNotEmpty(),
-            "the worker never started: featureReady=${featureReadyRan.get()} " +
+            "the worker never started, so this run proves nothing: featureReady=${featureReadyRan.get()} " +
                 "readyHook=${readyHookRan.get()} polls=${pollsCompleted.get()} " +
                 "failures=${pollFailures.toList()}",
         )
@@ -311,7 +317,7 @@ class ShutdownPhaseOrderingTest {
         const val CYCLES = 12
         const val BOOT_WAIT_SLICES = 100
         const val BOOT_WAIT_SLICE_MILLIS = 200L
-        const val POLL_WARMUP_MILLIS = 150L
+        const val POLL_WARMUP_TIMEOUT_MILLIS = 30_000L
         const val SETTLE_TIMEOUT_MILLIS = 3_000L
         const val SETTLE_POLL_MILLIS = 10L
     }

--- a/katalyst-di/src/test/kotlin/io/github/darkryh/katalyst/di/extension/ExtensionPointCatalogTest.kt
+++ b/katalyst-di/src/test/kotlin/io/github/darkryh/katalyst/di/extension/ExtensionPointCatalogTest.kt
@@ -58,6 +58,7 @@ class ExtensionPointCatalogTest {
             KatalystConventions.KATALYST_MIGRATION,
             KatalystConventions.APPLICATION_INITIALIZER,
             KatalystConventions.APPLICATION_READY_INITIALIZER,
+            KatalystConventions.APPLICATION_SHUTDOWN_HOOK,
         )
 
         val catalogFqns = ExtensionPoints.all.mapNotNull { it.type.qualifiedName }.toSet()

--- a/katalyst-di/src/test/kotlin/io/github/darkryh/katalyst/di/lifecycle/ShutdownHookRunnerTest.kt
+++ b/katalyst-di/src/test/kotlin/io/github/darkryh/katalyst/di/lifecycle/ShutdownHookRunnerTest.kt
@@ -1,0 +1,194 @@
+package io.github.darkryh.katalyst.di.lifecycle
+
+import io.github.darkryh.katalyst.di.registry.RegistryManager
+import io.github.darkryh.katalyst.di.test.TestBeanEngine
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * The contract [ShutdownHookRunner] has to hold for the shutdown phase to be worth having.
+ *
+ * Two of these are the whole reason the interface exists rather than reusing Ktor's
+ * `ApplicationStopping`: a hook is *awaited* (so a worker can join what it cancelled instead of only
+ * signalling it), and a hook that never comes back cannot hang the process.
+ *
+ * The hooks below are separate classes rather than one parameterised class because
+ * [ShutdownHookRegistry] keeps at most one instance per class — the same rule [ReadyHookRegistry]
+ * uses, and the reason a test written with three instances of one class silently exercises one.
+ */
+class ShutdownHookRunnerTest {
+
+    private lateinit var engine: TestBeanEngine
+    private lateinit var trace: CopyOnWriteArrayList<String>
+    private val latches = mutableListOf<CountDownLatch>()
+
+    @BeforeTest
+    fun setUp() {
+        RegistryManager.resetAll()
+        trace = CopyOnWriteArrayList()
+        engine = TestBeanEngine()
+        engine.start(emptyList(), allowOverrides = true)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        // Release anything still parked before the engine goes, or a blocked hook thread outlives
+        // the test class.
+        latches.forEach { it.countDown() }
+        latches.clear()
+        RegistryManager.resetAll()
+        engine.stop()
+    }
+
+    private fun latch(): CountDownLatch = CountDownLatch(1).also { latches += it }
+
+    @Test
+    fun `stops hooks in the reverse of the order they were started in`() = runBlocking {
+        // Startup runs ascending order; shutdown has to walk the same numbers backwards so a hook is
+        // stopped before the things it was started after.
+        ShutdownHookRegistry.register(AlphaHook(trace, order = -10))
+        ShutdownHookRegistry.register(BetaHook(trace, order = 10))
+        ShutdownHookRegistry.register(GammaHook(trace, order = 0))
+
+        ShutdownHookRunner(engine.container).invokeAll()
+
+        assertEquals(
+            listOf("beta-start", "beta-end", "gamma-start", "gamma-end", "alpha-start", "alpha-end"),
+            trace.toList(),
+        )
+    }
+
+    @Test
+    fun `awaits a suspending hook before moving on and before returning`() = runBlocking {
+        // THE reason ShutdownHook suspends. A synchronous ApplicationStopping subscriber can only
+        // ask a worker to stop; this has to be able to wait until it actually has, or the pool still
+        // closes under an in-flight statement.
+        ShutdownHookRegistry.register(BetaHook(trace, order = 10) { delay(250) })
+        ShutdownHookRegistry.register(AlphaHook(trace, order = 0))
+
+        val report = ShutdownHookRunner(engine.container).invokeAll()
+
+        assertEquals(
+            listOf("beta-start", "beta-end", "alpha-start", "alpha-end"),
+            trace.toList(),
+            "a hook that suspends must be finished before the next one starts and before the " +
+                "runner returns - otherwise teardown races the work it just asked to stop",
+        )
+        assertTrue(report.isClean)
+    }
+
+    @Test
+    fun `a failing hook does not stop the others and is reported`() = runBlocking {
+        ShutdownHookRegistry.register(BetaHook(trace, order = 10) { error("hook exploded") })
+        ShutdownHookRegistry.register(AlphaHook(trace, order = 0))
+
+        val report = ShutdownHookRunner(engine.container).invokeAll()
+
+        assertContains(trace, "alpha-end", "a failure must not abandon the remaining cleanup")
+        assertEquals(listOf("beta"), report.failed)
+        assertTrue(report.timedOut.isEmpty())
+        assertFalse(report.isClean)
+    }
+
+    @Test
+    fun `a hook that never returns is abandoned instead of hanging the shutdown`() {
+        // Blocking, not suspending, because that is the real case: a coroutine parked in a JDBC call
+        // cannot observe cancellation, so the runner has to be able to stop *waiting* for a hook it
+        // has no way to interrupt.
+        val stuck = latch()
+        ShutdownHookRegistry.register(BetaHook(trace, order = 10) { stuck.await(30, TimeUnit.SECONDS) })
+        ShutdownHookRegistry.register(AlphaHook(trace, order = 0))
+
+        val startedAt = System.nanoTime()
+        val report = runBlocking {
+            ShutdownHookRunner(engine.container, hookTimeout = 200.milliseconds).invokeAll()
+        }
+        val elapsedMillis = (System.nanoTime() - startedAt) / 1_000_000
+
+        assertEquals(listOf("beta"), report.timedOut)
+        assertContains(trace, "alpha-end", "the hooks behind a stuck one still have to run")
+        assertTrue(
+            elapsedMillis < 10_000,
+            "the shutdown waited $elapsedMillis ms on a hook it should have abandoned after 200 ms",
+        )
+    }
+
+    @Test
+    fun `two distinct instances of the same hook class both run`() = runBlocking {
+        // Dedup is by identity, not by class: the registry and the container legitimately hold
+        // different instances, and both own something that needs stopping.
+        engine.registerInstance(AlphaHook(trace), ShutdownHook::class)
+        ShutdownHookRegistry.register(AlphaHook(trace))
+
+        val report = ShutdownHookRunner(engine.container).invokeAll()
+
+        assertEquals(2, report.executed)
+        assertEquals(listOf("alpha-start", "alpha-end", "alpha-start", "alpha-end"), trace.toList())
+    }
+
+    @Test
+    fun `no hooks is a no-op`() = runBlocking {
+        val report = ShutdownHookRunner(engine.container).invokeAll()
+
+        assertEquals(ShutdownHookReport.NOTHING_TO_DO, report)
+    }
+
+    @Test
+    fun `a missing container still runs the registry hooks`() = runBlocking {
+        // The teardown path resolves the container defensively; losing it must not silently skip
+        // every hook the registry already holds.
+        ShutdownHookRegistry.register(AlphaHook(trace))
+
+        val report = ShutdownHookRunner(container = null).invokeAll()
+
+        assertEquals(1, report.executed)
+        assertContains(trace, "alpha-end")
+    }
+}
+
+private abstract class RecordingShutdownHook(
+    private val trace: MutableList<String>,
+    override val order: Int,
+    private val body: suspend () -> Unit,
+) : ShutdownHook {
+    override suspend fun onShutdown() {
+        trace += "$id-start"
+        body()
+        trace += "$id-end"
+    }
+}
+
+private class AlphaHook(
+    trace: MutableList<String>,
+    order: Int = 0,
+    body: suspend () -> Unit = {},
+) : RecordingShutdownHook(trace, order, body) {
+    override val id: String = "alpha"
+}
+
+private class BetaHook(
+    trace: MutableList<String>,
+    order: Int = 0,
+    body: suspend () -> Unit = {},
+) : RecordingShutdownHook(trace, order, body) {
+    override val id: String = "beta"
+}
+
+private class GammaHook(
+    trace: MutableList<String>,
+    order: Int = 0,
+    body: suspend () -> Unit = {},
+) : RecordingShutdownHook(trace, order, body) {
+    override val id: String = "gamma"
+}

--- a/katalyst-scheduler/api/katalyst-scheduler.api
+++ b/katalyst-scheduler/api/katalyst-scheduler.api
@@ -50,6 +50,7 @@ public final class io/github/darkryh/katalyst/scheduler/SchedulerFeature : io/gi
 	public static final field INSTANCE Lio/github/darkryh/katalyst/scheduler/SchedulerFeature;
 	public fun getId ()Ljava/lang/String;
 	public fun onReady (Lio/github/darkryh/katalyst/di/feature/KatalystBeanContext;)V
+	public fun onShutdown (Lio/github/darkryh/katalyst/di/feature/KatalystBeanContext;)V
 	public fun provideBeanModules ()Ljava/util/List;
 }
 

--- a/observability/katalyst-telemetry/api/katalyst-telemetry.api
+++ b/observability/katalyst-telemetry/api/katalyst-telemetry.api
@@ -32,6 +32,7 @@ public final class io/github/darkryh/katalyst/telemetry/TelemetryFeature : io/gi
 	public static final field INSTANCE Lio/github/darkryh/katalyst/telemetry/TelemetryFeature;
 	public fun getId ()Ljava/lang/String;
 	public fun onReady (Lio/github/darkryh/katalyst/di/feature/KatalystBeanContext;)V
+	public fun onShutdown (Lio/github/darkryh/katalyst/di/feature/KatalystBeanContext;)V
 	public fun provideBeanModules ()Ljava/util/List;
 }
 


### PR DESCRIPTION
## The defect

Katalyst had a startup lifecycle (`StartupHook` → `ReadyHook`) and **nothing on the way down**. It tore itself down from Ktor's `ApplicationStopping`, closing the connection pool while application background work was still querying. Shutdowns ended in:

```
WARN  HikariPool-1 - Connection marked as broken because of SQLSTATE(08006)
      PSQLException: An I/O error occurred while sending to the backend
      Caused by: java.net.SocketException: Socket closed
ERROR Non-retryable exception in transaction ... IllegalStateException:
      No transaction manager for db ExposedDatabase[1665209618](null)
```

Not a crash — the process exits normally — but alarming, and it meant the framework was cutting off work it had invited. `ReadyHook`'s own KDoc recommends it for "background activations such as scheduler jobs, consumers, and polling loops".

Reproduced on a plain Ctrl+C in `samples/katalyst-example` with a throwaway polling `ReadyHook`, TUI and telemetry off. **Identical on 1.0.0-beta02 and 1.0.0-beta03** — present since at least alpha10, not a recent regression.

## Three failure modes, three layers

No single change fixes all three, which is what the shape of this PR is about:

| | Failure | Fixed by |
|---|---|---|
| **F1** | No contract — nowhere for an application to be called | `ShutdownHook` |
| **F2** | Wrong order — consumer `ApplicationStopping` handlers ran *after* teardown | teardown moves to `ApplicationStopped` |
| **F3** | **No join** — `ApplicationStopping` subscribers are synchronous, so `job.cancel()` returns while the coroutine is still inside a blocking JDBC call | `suspend fun onShutdown()`, awaited + bounded pool quiesce |

F3 is the one that matters most: **fixing the ordering alone does not fix a fire-and-forget `cancel()`**, which is what real applications write.

## What lands

- **`ShutdownHook : LifecycleHook`** with `suspend fun onShutdown()` — discovered like `ReadyHook`, run in descending `order`, **awaited**, per-hook timeout, failures isolated. Each hook runs as its own job so the timeout can actually take effect against a hook blocked in JDBC.
- **`LifecycleHook`** now carries `id`/`order` for all three hook interfaces. Previously each declared its own defaults, so a class implementing two had to override both for no reason.
- **`KatalystFeature.onShutdown(context)`** — the same gap one level up, noted in `TelemetryFeature`'s own KDoc.
- **Teardown moves `ApplicationStopping` → `ApplicationStopped`**, putting Katalyst last.
- **`DatabaseFactory.quiesce(timeout)`** — bounded 2 s wait for connections to return before the pool closes; WARNs naming how many are still checked out if it expires.

Resulting order: HTTP drain → `ApplicationStopping` (app) → `ShutdownHook`s → features → pool quiesce → teardown.

## Tests

| Suite | Cases | Pins |
|---|---|---|
| `ShutdownHookRunnerTest` | 7 | reverse order; **a suspending hook is awaited**; a failing hook doesn't abandon the rest; a hook that never returns is abandoned, not fatal |
| `ShutdownPhaseOrderingTest` | 6 | boots a real application whose worker hammers the database, stops it, asserts **zero failed queries**; `ApplicationStopping`/`ShutdownHook`/feature-stop all see a live database; 12-cycle stress loop |
| `DatabaseQuiesceTest` | 5 | returns when idle, waits while held, gives up at the budget and reports |

**Verified the guard works:** with the fix reverted, **all 6** of `ShutdownPhaseOrderingTest` fail. The first version of the headline test passed even without the fix — it was racing the worker rather than testing it — so it now settles before asserting.

Full suite: **2486 tests, 0 failures**. `check`, `apiCheck`, `koverVerify` green. Every commit in the branch is independently buildable and green.

## End-to-end

Real Netty, real Postgres, real SIGINT, in `samples/katalyst-example`:

- **A consumer's existing `ApplicationStopping` + fire-and-forget `cancel()` shape, unchanged** — 5/5 runs clean, with a 10–34 ms quiesce gap before the pool closes. No `08006`, no `Socket closed`, no `No transaction manager`.
- **`ShutdownHook` adopted** — 3/3 clean, one run showing the join waiting 290 ms for an in-flight tick before the pool closed.

## API note

`ReadyHook` and `StartupHook` lose their own `getId`/`getOrder` (and their `DefaultImpls`) to `LifecycleHook`. Source-compatible; binary-breaking for already-compiled implementors, which is acceptable pre-1.0. `apiDump` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)